### PR TITLE
Update dependency to Alexandria 2.14.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,4 +6,4 @@ find_package(ElementsProject)
 #---------------------------------------------------------------
 
 # Declare project name and version
-elements_project(SExtractorxx 0.1 USE Alexandria 2.14 Elements 5.8)
+elements_project(SExtractorxx 0.1 USE Alexandria 2.14.1 Elements 5.8)


### PR DESCRIPTION
Alexandria 2.14.1 depends directly on Elements 5.8, so we can hopefully stop with
the deuclidized branches.

Also, this should make possible to compile directly in LODEEN, which
we will need for the dev workshop.