### PR TITLE
Fix and improve the AppImage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ jobs:
     env: OS_TYPE=centos OS_VERSION=7
   - stage: buildapp
     if: tag IS present
-    env: OS_TYPE=fedora OS_VERSION=29
+    env: OS_TYPE=centos OS_VERSION=7
     script:
       - docker run --name appbuilder --device /dev/fuse --privileged --volume "$(pwd):/src" "${OS_TYPE}:${OS_VERSION}" bash "/src/.travis/build-appimage.sh"
       - docker cp "appbuilder:/sextractor++-x86_64.AppImage" "."

--- a/.travis/build-rpm.sh
+++ b/.travis/build-rpm.sh
@@ -51,6 +51,7 @@ yum install -y -q boost-devel $PYTHON-pytest log4cpp-devel doxygen CCfits-devel
 yum install -y -q graphviz $PYTHON-sphinx $PYTHON-sphinxcontrib-apidoc
 yum install -y -q gmock-devel gtest-devel
 yum install -y -q ${PYTHON}-devel boost-${PYTHON}-devel fftw-devel levmar-devel wcslib-devel
+yum install -y -q ncurses-devel readline-devel
 
 # Build
 mkdir -p /build

--- a/SEMain/scripts/AppRun
+++ b/SEMain/scripts/AppRun
@@ -25,15 +25,16 @@
 # We need to properly set up the PYTHONPATH so the sextractor++ modules can be found
 # within the image
 
-export APPIMAGE_MOUNT="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+export PATH="${APPDIR}/usr/bin:${PATH}"
 
-PYTHONDIRNAME="$(ls -1 ${APPIMAGE_MOUNT}/usr/lib64/ | grep '^python')"
+if [ -f "${APPDIR}/usr/bin/python3" ]; then
+    PYTHON_VERSION=$(python3 -c "import sys; print('{}.{}'.format(sys.version_info.major, sys.version_info.minor))")
+else
+    PYTHON_VERSION=$(python -c "import sys; print('{}.{}'.format(sys.version_info.major, sys.version_info.minor))")
+fi
 
-LIB="${APPIMAGE_MOUNT}/usr/lib"
-LIB64="${APPIMAGE_MOUNT}/usr/lib64"
-LIBPYTHON="${APPIMAGE_MOUNT}/usr/lib64/${PYTHONDIRNAME}/site-packages"
+PYTHON_LIBS="${APPDIR}/usr/lib64/python${PYTHON_VERSION}/"
 
-export PYTHONPATH="${LIB}:${LIB64}:${LIBPYTHON}"
-source "${APPIMAGE_MOUNT}/bin/activate"
+export PYTHONPATH="${PYTHON_LIBS}:${PYTHON_LIBS}/site-packages"
+exec -a "${ARGV0}" "${APPDIR}/usr/bin/sextractor++" $@
 
-exec -a "${APPIMAGE_MOUNT}/sextractor++" "${APPIMAGE_MOUNT}/usr/bin/sextractor++" $@

--- a/SEMain/scripts/AppRun
+++ b/SEMain/scripts/AppRun
@@ -33,8 +33,14 @@ else
     PYTHON_VERSION=$(python -c "import sys; print('{}.{}'.format(sys.version_info.major, sys.version_info.minor))")
 fi
 
-PYTHON_LIBS="${APPDIR}/usr/lib64/python${PYTHON_VERSION}/"
+LIB="${APPDIR}/usr/lib"
+LIB64="${APPDIR}/usr/lib64"
 
-export PYTHONPATH="${PYTHON_LIBS}:${PYTHON_LIBS}/site-packages"
+PYTHON_LIB="${LIB}/python${PYTHON_VERSION}"
+PYTHON64_LIB="${LIB64}/python${PYTHON_VERSION}"
+
+export PYTHONPATH="${PYTHON_LIB}:${PYTHON_LIB}/site-packages:${PYTHON64_LIB}:${PYTHON64_LIB}/site-packages"
+export LD_LIBRARY_PATH="${LIB64}:${LIB}:${LIB64}/atlas:${LD_LIBRARY_PATH}"
+
 exec -a "${ARGV0}" "${APPDIR}/usr/bin/sextractor++" $@
 


### PR DESCRIPTION
* Use `yum install --installroot` instead of the pip/virtualenv mess
* Install ncurses when compiling the rpms, to get the UI
* Base the AppImage on CentOS 7
  - Normally one should target the oldest version willing to support, as the resulting binary will be able to run in any system with a more recent glibc, but likely not on a system with an older one

I have taken the liberty of building a new AppImage and replacing the one attached to the 0.6.1 release (the rpms are the same, the procedure changes). It runs fine on a Fedora 30 and a CentOS 7 alike (model fitting included!).